### PR TITLE
the abs() sefun exists as a driver efun. 

### DIFF
--- a/lib/secure/simul_efun/misc.c
+++ b/lib/secure/simul_efun/misc.c
@@ -87,14 +87,6 @@ string *rev_explode(string arr_in, string delim)
   return arr_out;
 }
 
-//:FUNCTION abs
-// Absolute value function
-int abs(int x)
-{
-   return x < 0 ? -x : x;
-}
-
-
 //:FUNCTION cmp
 //returns whether its two arguments are equivalent.  This is about
 //the same as using the equivalence operator (==), but will return true


### PR DESCRIPTION
no longer required as a abs() sefun exists as a driver efun. no longerr required as a simulated efun.