### PR TITLE
new message types and wrap/prompt handling

### DIFF
--- a/lib/include/msgtypes.h
+++ b/lib/include/msgtypes.h
@@ -8,8 +8,10 @@
 #define OUTSIDE_MSG	2
 #define REMOTE_MSG	3
 
-#define NO_WRAP		4
-#define MSG_INDENT	8
-#define NO_ANSI		16
+#define NO_WRAP		     4
+#define MSG_INDENT	     8
+#define NO_ANSI		    16
+#define TREAT_AS_BLOB   32
+#define MSG_PROMPT      (64 | TREAT_AS_BLOB)
 
 #endif /* __MSGTYPES_H__ */

--- a/lib/secure/user/inputsys.c
+++ b/lib/secure/user/inputsys.c
@@ -221,7 +221,7 @@ protected nomask void modal_recapture()
         // and therefore you may not tell it to not wrap prompts, which auto-
         // matically appends \n
 	    // write(prompt); 
-        if(this_body()) this_body()->do_receive(prompt, NO_WRAP) ;
+        if(this_body()) this_body()->do_receive(prompt, MSG_PROMPT) ;
     }
     if ( info->input_type == INPUT_CHAR_MODE )
     {


### PR DESCRIPTION
Several updates in this PR

### Message types
TREAT_AS_BLOB : will not send individual exploded lines to recursive call `do_receive()`
MSG_PROMPT : will prevent appending final \n after all processing, and send telnet_ga() and also incorporates TREAT_AS_BLOB

### The do_receive() function
Will now do only *1* receive() call after all manips have been decided and completed. So, uses the initial explode and parses them all as necessary, finally ending in decision what to do if prompt.